### PR TITLE
Add minimal Hola Mundo API for Fly.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # API_PRUEBA
+
+API de prueba lista para desplegar en [Fly.io](https://fly.io) que expone un único endpoint y responde "Hola Mundo".
+
+## Requisitos
+
+- Node.js 18 o superior.
+
+## Uso local
+
+```bash
+npm install # No instala dependencias adicionales, pero mantiene el flujo habitual
+npm start
+```
+
+Luego visita `http://localhost:3000` para ver la respuesta JSON `{"mensaje":"Hola Mundo"}`.
+
+## Configuración para Fly.io
+
+Fly.io inyecta el puerto de escucha a través de la variable de entorno `PORT`, por lo que no es necesario realizar cambios adicionales. Solo asegúrate de exponer el proceso de Node.js mediante `fly launch` y `fly deploy` siguiendo la documentación oficial.

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,8 @@
+# Reemplaza "api-prueba" por el nombre de tu aplicación en Fly.io
+app = "api-prueba"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_start_machines = true
+  auto_stop_machines = true

--- a/index.js
+++ b/index.js
@@ -1,0 +1,16 @@
+import http from 'http';
+
+const PORT = process.env.PORT || 3000;
+
+const requestListener = (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'application/json; charset=utf-8',
+  });
+  res.end(JSON.stringify({ mensaje: 'Hola Mundo' }));
+};
+
+const server = http.createServer(requestListener);
+
+server.listen(PORT, () => {
+  console.log(`Servidor de prueba escuchando en http://localhost:${PORT}`);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "api_prueba",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "api_prueba",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "api_prueba",
+  "version": "1.0.0",
+  "description": "API de prueba que responde Hola Mundo.",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "keywords": [
+    "api",
+    "hola",
+    "mundo"
+  ],
+  "author": "",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add a lightweight Node.js HTTP server that responde Hola Mundo en JSON
- documentar cómo ejecutar la API localmente y desplegarla en Fly.io
- incluir un archivo `fly.toml` de ejemplo con el puerto configurado

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e515a2d8088332833f091775368231